### PR TITLE
Fix cron workflow indentation

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -14,13 +14,9 @@ env:
   AUTOTHROTTLE_MAX_DELAY: 30.0
   AUTOTHROTTLE_START_DELAY: 1.5
   AUTOTHROTTLE_TARGET_CONCURRENCY: 3.0
-  # Add secrets for the platform you're using and uncomment here
-   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-   S3_BUCKET: ${{ secrets.S3_BUCKET }}
-  # AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
-  # AZURE_ACCOUNT_NAME: ${{ secrets.AZURE_ACCOUNT_NAME }}
-  # AZURE_CONTAINER: ${{ secrets.AZURE_CONTAINER }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  S3_BUCKET: ${{ secrets.S3_BUCKET }}
   # Setup Sentry, add the DSN to secrets and uncomment here
   # SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 


### PR DESCRIPTION
This is all looking really great so far! Fixed the indentation because YAML can be picky and removed some of the unneeded comments. After this is merged you should be able to trigger the Cron workflow manually, but Actions are still new/I might be missing something